### PR TITLE
specify minimal Perl version

### DIFF
--- a/lib/WWW/Pusher/Client.pm
+++ b/lib/WWW/Pusher/Client.pm
@@ -3,6 +3,7 @@ package WWW::Pusher::Client;
 
 use strict;
 use warnings;
+use 5.010_001;
 use Moo;
 use JSON;
 use AnyEvent::WebSocket::Client;


### PR DESCRIPTION
This module uses logical defined-or operator(`//`). It was introduced at Perl 5.10.
